### PR TITLE
minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ $ slither.py file.sol
 ``` 
 
 ``` 
-$ slither.py examples/uninitialized.sol
+$ slither.py examples/bugs/uninitialized.sol
 [..]
-INFO:Detectors:Uninitialized state variables in examples/uninitialized.sol, Contract: Uninitialized, Vars: destination, Used in ['transfer']
+INFO:Detectors:Uninitialized state variables in examples/bugs/uninitialized.sol, Contract: Uninitialized, Vars: destination, Used in ['transfer']
 [..]
 ``` 
 

--- a/examples/bugs/uninitialized.sol
+++ b/examples/bugs/uninitialized.sol
@@ -1,9 +1,11 @@
+pragma solidity ^0.4.24;
+
 contract Uninitialized{
 
 
     address destination;
 
-    function transfer() payable{
+    function transfer() public payable{
     
         destination.transfer(msg.value);
     }


### PR DESCRIPTION
Looks like a "bugs" directory was created at some point, and the solc warnings were a bit annoying when running through the example commands in the "how to use" section, so I added a pragama, and explicitly declared the method as public.