### PR TITLE
Naming Convention Detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check | Purpose | Impact | Confidence
 `--detect-pragma`| Detect if different pragma directives are used | Informational | High
 `--detect-solc-version`| Detect if an old version of Solidity used (<0.4.23) | Informational | High
 `--detect-unused-state`| Detect unused state variables | Informational | High
-`--detect-naming-convention`| Detect conformance to Solidity naming conventions | Informational | Informational
+`--detect-naming-convention`| Detect conformance to Solidity naming conventions | Informational | High
 
 [Contact us](https://www.trailofbits.com/contact/) to get access to additional detectors.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Check | Purpose | Impact | Confidence
 `--detect-pragma`| Detect if different pragma directives are used | Informational | High
 `--detect-solc-version`| Detect if an old version of Solidity used (<0.4.23) | Informational | High
 `--detect-unused-state`| Detect unused state variables | Informational | High
-`--detect-naming-convention`| Detect Naming Convention violations | Informational | Informational
+`--detect-naming-convention`| Detect conformance to Solidity naming conventions | Informational | Informational
 
 [Contact us](https://www.trailofbits.com/contact/) to get access to additional detectors.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Check | Purpose | Impact | Confidence
 `--detect-pragma`| Detect if different pragma directives are used | Informational | High
 `--detect-solc-version`| Detect if an old version of Solidity used (<0.4.23) | Informational | High
 `--detect-unused-state`| Detect unused state variables | Informational | High
+`--detect-naming-convention`| Detect Naming Convention violations | Informational | Informational
 
 [Contact us](https://www.trailofbits.com/contact/) to get access to additional detectors.
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -55,12 +55,12 @@ fi
 
 
 slither tests/inline_assembly_contract.sol --disable-solc-warnings
-if [ $? -ne 2 ]; then
+if [ $? -ne 3 ]; then
     exit 1
 fi
 
 slither tests/inline_assembly_library.sol --disable-solc-warnings
-if [ $? -ne 3 ]; then
+if [ $? -ne 6 ]; then
     exit 1
 fi
 

--- a/scripts/travis_test.sh
+++ b/scripts/travis_test.sh
@@ -9,7 +9,7 @@ fi
 
 # contains also the test for the suicidal detector
 slither tests/backdoor.sol --disable-solc-warnings
-if [ $? -ne 2 ]; then
+if [ $? -ne 3 ]; then
     exit 1
 fi
 
@@ -24,7 +24,7 @@ if [ $? -ne 1 ]; then
 fi
 
 slither tests/reentrancy.sol --disable-solc-warnings
-if [ $? -ne 1 ]; then
+if [ $? -ne 4 ]; then
     exit 1
 fi
 
@@ -53,6 +53,10 @@ if [ $? -ne 2 ]; then
     exit 1
 fi
 
+slither tests/naming_convention.sol --disable-solc-warnings
+if [ $? -ne 10 ]; then
+    exit 1
+fi
 
 
 ### Test scripts

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -100,6 +100,7 @@ def main():
     from slither.detectors.variables.uninitialized_storage_variables import UninitializedStorageVars
     from slither.detectors.variables.unused_state_variables import UnusedStateVars
     from slither.detectors.statements.tx_origin import TxOrigin
+    from slither.detectors.naming_convention.naming_convention import NamingConvention
 
     detectors = [Backdoor,
                  UninitializedStateVarsDetection,
@@ -111,7 +112,8 @@ def main():
                  ArbitrarySend,
                  Suicidal,
                  UnusedStateVars,
-                 TxOrigin]
+                 TxOrigin,
+                 NamingConvention]
 
     from slither.printers.summary.summary import PrinterSummary
     from slither.printers.summary.quick_summary import PrinterQuickSummary

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -1,0 +1,154 @@
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+import re
+
+
+class NamingConvention(AbstractDetector):
+    """
+    Check if naming conventions are followed
+    https://solidity.readthedocs.io/en/v0.4.25/style-guide.html?highlight=naming_convention%20convention#naming_convention-conventions
+    """
+
+    ARGUMENT = 'naming-convention'
+    HELP = 'naming convention violations'
+    IMPACT = DetectorClassification.INFORMATIONAL
+    CONFIDENCE = DetectorClassification.INFORMATIONAL
+
+    @staticmethod
+    def is_cap_words(name):
+        return re.search('^[A-Z]([A-Za-z0-9]+)?_?$', name) is not None
+
+    @staticmethod
+    def is_mixed_case(name):
+        return re.search('^[a-z]([A-Za-z0-9]+)?_?$', name) is not None
+
+    @staticmethod
+    def is_upper_case_with_underscores(name):
+        return re.search('^[A-Z0-9_]+_?$', name) is not None
+
+    @staticmethod
+    def should_avoid_name(name):
+        return re.search('^[lOI]$', name) is not None
+
+    def detect(self):
+
+        results = []
+        for contract in self.contracts:
+
+            if self.is_cap_words(contract.name) is False:
+                info = " Contract '{}' is not in CapWords".format(contract.name)
+                self.log(info)
+
+                results.append({'vuln': 'NamingConvention',
+                                'filename': self.filename,
+                                'contract': contract.name,
+                                'sourceMapping': contract.source_mapping})
+
+            for struct in contract.structures:
+
+                if self.is_cap_words(struct.name) is False:
+                    info = " Struct '{}' is not in CapWords, Contract: '{}' ".format(struct.name, contract.name)
+                    self.log(info)
+
+                    results.append({'vuln': 'NamingConvention',
+                                    'filename': self.filename,
+                                    'contract': contract.name,
+                                    'struct': struct.name,
+                                    'sourceMapping': struct.source_mapping})
+
+            for event in contract.events:
+
+                if self.is_cap_words(event.name) is False:
+                    info = " Event '{}' is not in CapWords, Contract: '{}' ".format(event.name, contract.name)
+                    self.log(info)
+
+                    results.append({'vuln': 'NamingConvention',
+                                    'filename': self.filename,
+                                    'contract': contract.name,
+                                    'event': event.name,
+                                    'sourceMapping': event.source_mapping})
+
+            for func in contract.functions:
+
+                if self.is_mixed_case(func.name) is False:
+                    info = " Function '{}' is not in mixedCase, Contract: '{}' ".format(func.name, contract.name)
+                    self.log(info)
+
+                    results.append({'vuln': 'NamingConvention',
+                                    'filename': self.filename,
+                                    'contract': contract.name,
+                                    'function': func.name,
+                                    'sourceMapping': func.source_mapping})
+
+                for argument in func.parameters:
+
+                    if self.is_mixed_case(argument.name) is False:
+                        info = " Parameter '{}' is not in mixedCase, Contract: '{}', Function: '{}'' " \
+                            .format(argument.name, argument.name, contract.name)
+                        self.log(info)
+
+                        results.append({'vuln': 'NamingConvention',
+                                        'filename': self.filename,
+                                        'contract': contract.name,
+                                        'function': func.name,
+                                        'argument': argument.name,
+                                        'sourceMapping': argument.source_mapping})
+
+            for var in contract.state_variables:
+
+                if self.should_avoid_name(var.name):
+                    if self.is_upper_case_with_underscores(var.name) is False:
+                        info = " Variable '{}' l, O, I should not be used, Contract: '{}' " \
+                            .format(var.name, contract.name)
+                        self.log(info)
+
+                        results.append({'vuln': 'NamingConvention',
+                                        'filename': self.filename,
+                                        'contract': contract.name,
+                                        'constant': var.name,
+                                        'sourceMapping': var.source_mapping})
+
+                if var.is_constant is True:
+                    if self.is_upper_case_with_underscores(var.name) is False:
+                        info = " Constant '{}' is not in UPPER_CASE_WITH_UNDERSCORES, Contract: '{}' " \
+                            .format(var.name, contract.name)
+                        self.log(info)
+
+                        results.append({'vuln': 'NamingConvention',
+                                        'filename': self.filename,
+                                        'contract': contract.name,
+                                        'constant': var.name,
+                                        'sourceMapping': var.source_mapping})
+                else:
+                    if self.is_mixed_case(var.name) is False:
+                        info = " Variable '{}' is not in mixedCase, Contract: '{}' ".format(var.name, contract.name)
+                        self.log(info)
+
+                        results.append({'vuln': 'NamingConvention',
+                                        'filename': self.filename,
+                                        'contract': contract.name,
+                                        'variable': var.name,
+                                        'sourceMapping': var.source_mapping})
+
+            for enum in contract.enums:
+                if self.is_cap_words(enum.name) is False:
+                    info = " Enum '{}' is not in CapWords, Contract: '{}' ".format(enum.name, contract.name)
+                    self.log(info)
+
+                    results.append({'vuln': 'NamingConvention',
+                                    'filename': self.filename,
+                                    'contract': contract.name,
+                                    'enum': enum.name,
+                                    'sourceMapping': enum.source_mapping})
+
+            for modifier in contract.modifiers:
+                if self.is_mixed_case(modifier.name) is False:
+                    info = " Modifier '{}' is not in mixedCase, Contract: '{}' ".format(modifier.name, contract.name)
+                    self.log(info)
+
+                    results.append({'vuln': 'NamingConvention',
+                                    'filename': self.filename,
+                                    'contract': contract.name,
+                                    'modifier': modifier.name,
+                                    'sourceMapping': modifier.source_mapping})
+
+        return results

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -9,7 +9,7 @@ class NamingConvention(AbstractDetector):
     """
 
     ARGUMENT = 'naming-convention'
-    HELP = 'naming convention violations'
+    HELP = 'conformance to Solidity naming conventions'
     IMPACT = DetectorClassification.INFORMATIONAL
     CONFIDENCE = DetectorClassification.HIGH
 

--- a/slither/detectors/naming_convention/naming_convention.py
+++ b/slither/detectors/naming_convention/naming_convention.py
@@ -11,7 +11,7 @@ class NamingConvention(AbstractDetector):
     ARGUMENT = 'naming-convention'
     HELP = 'naming convention violations'
     IMPACT = DetectorClassification.INFORMATIONAL
-    CONFIDENCE = DetectorClassification.INFORMATIONAL
+    CONFIDENCE = DetectorClassification.HIGH
 
     @staticmethod
     def is_cap_words(name):

--- a/tests/naming_convention.sol
+++ b/tests/naming_convention.sol
@@ -1,0 +1,60 @@
+pragma solidity ^0.4.24;
+
+contract naming {
+
+    enum Numbers {ONE, TWO}
+    enum numbers {ONE, TWO}
+
+    uint constant MY_CONSTANT = 1;
+    uint constant MY_other_CONSTANT = 2;
+
+    uint Var_One = 1;
+    uint varTwo = 2;
+
+    struct test {
+
+    }
+
+    struct Test {
+
+    }
+
+    event Event_(uint);
+    event event_(uint);
+
+    function getOne() constant returns (uint)
+    {
+        return 1;
+    }
+
+    function GetOne() constant returns (uint)
+    {
+        return 1;
+    }
+
+    function setInt(uint number1, uint Number2)
+    {
+
+    }
+
+
+    modifier CantDo() {
+        _;
+    }
+
+    modifier canDo() {
+        _;
+    }
+}
+
+contract Test {
+
+}
+
+contract T {
+    uint k = 1;
+
+    uint constant M = 1;
+
+    uint l = 1;
+}


### PR DESCRIPTION
This pr adds a detector for naming convention violations.
fixes #24

Some tests violate naming conventions  and I had to update the expected number of results in order for the tests to succeed.
I think it is better to limit each test case to only run the detector for which the test was made for.
