### PR TITLE
update detector descriptions witht txt from README

### DIFF
--- a/slither/detectors/attributes/old_solc.py
+++ b/slither/detectors/attributes/old_solc.py
@@ -12,7 +12,7 @@ class OldSolc(AbstractDetector):
     """
 
     ARGUMENT = 'solc-version'
-    HELP = 'If an old version of Solidity used (<0.4.23)'
+    HELP = 'Old versions of Solidity (< 0.4.23)'
     IMPACT = DetectorClassification.INFORMATIONAL
     CONFIDENCE = DetectorClassification.HIGH
 

--- a/slither/detectors/functions/arbitrary_send.py
+++ b/slither/detectors/functions/arbitrary_send.py
@@ -27,7 +27,7 @@ class ArbitrarySend(AbstractDetector):
     """
 
     ARGUMENT = 'arbitrary-send'
-    HELP = 'Functions that send ether to an arbitrary destination'
+    HELP = 'Functions that send ether to arbitrary destinations'
     IMPACT = DetectorClassification.HIGH
     CONFIDENCE = DetectorClassification.MEDIUM
 


### PR DESCRIPTION
The descriptions for `solc-version` and `arbitrary-send` detectors were changed in the README but not in the actual detector code, this has been fixed.
