### PR TITLE
Normalize detectors json output function properties

### DIFF
--- a/slither/detectors/functions/arbitrary_send.py
+++ b/slither/detectors/functions/arbitrary_send.py
@@ -116,7 +116,7 @@ class ArbitrarySend(AbstractDetector):
                                 'sourceMapping': source_mapping,
                                 'filename': self.filename,
                                 'contract': func.contract.name,
-                                'func': func.name,
+                                'function': func.name,
                                 'calls': calls_str})
 
         return results

--- a/slither/detectors/functions/complex_function.py
+++ b/slither/detectors/functions/complex_function.py
@@ -111,6 +111,6 @@ class ComplexFunction(AbstractDetector):
                                 'sourceMapping': func.source_mapping,
                                 'filename': self.filename,
                                 'contract': contract.name,
-                                'func': func_name})
+                                'function': func_name})
         return results
 

--- a/slither/detectors/functions/external_function.py
+++ b/slither/detectors/functions/external_function.py
@@ -68,7 +68,7 @@ class ExternalFunction(AbstractDetector):
                                 'sourceMapping': func.source_mapping,
                                 'filename': self.filename,
                                 'contract': func.contract.name,
-                                'func': func.name})
+                                'function': func.name})
         if all_info != '':
             self.log(all_info)
         return results

--- a/slither/detectors/functions/suicidal.py
+++ b/slither/detectors/functions/suicidal.py
@@ -68,6 +68,6 @@ class Suicidal(AbstractDetector):
                                 'sourceMapping': func.source_mapping,
                                 'filename': self.filename,
                                 'contract': c.name,
-                                'func': func.name})
+                                'function': func.name})
 
         return results

--- a/slither/detectors/operations/low_level_calls.py
+++ b/slither/detectors/operations/low_level_calls.py
@@ -55,7 +55,7 @@ class LowLevelCalls(AbstractDetector):
                                 'sourceMapping': sourceMapping,
                                 'filename': self.filename,
                                 'contract': func.contract.name,
-                                'function_name': func.name})
+                                'function': func.name})
 
         if all_info != '':
             self.log(all_info)

--- a/slither/detectors/reentrancy/reentrancy.py
+++ b/slither/detectors/reentrancy/reentrancy.py
@@ -206,7 +206,7 @@ class Reentrancy(AbstractDetector):
                             'sourceMapping': source,
                             'filename': self.filename,
                             'contract': func.contract.name,
-                            'function_name': func.name,
+                            'function': func.name,
                             'calls': [str(x.expression) for x in calls],
                             'send_eth': [str(x.expression) for x in send_eth],
                             'varsWritten': [str(x) for (x,_) in varsWritten]})

--- a/slither/detectors/shadowing/shadowing_functions.py
+++ b/slither/detectors/shadowing/shadowing_functions.py
@@ -45,6 +45,6 @@ class ShadowingFunctionsDetection(AbstractDetector):
                                     'filename': self.filename,
                                     'contractShadower': c.name,
                                     'contract': contract.name,
-                                    'funcs': list(funcs)})
+                                    'functions': list(funcs)})
 
         return results

--- a/slither/detectors/statements/assembly.py
+++ b/slither/detectors/statements/assembly.py
@@ -55,7 +55,7 @@ class Assembly(AbstractDetector):
                                 'sourceMapping': sourceMapping,
                                 'filename': self.filename,
                                 'contract': func.contract.name,
-                                'function_name': func.name})
+                                'function': func.name})
 
         if all_info != '':
             self.log(all_info)

--- a/slither/detectors/statements/tx_origin.py
+++ b/slither/detectors/statements/tx_origin.py
@@ -64,6 +64,6 @@ class TxOrigin(AbstractDetector):
                                 'sourceMapping': sourceMapping,
                                 'filename': self.filename,
                                 'contract': func.contract.name,
-                                'function_name': func.name})
+                                'function': func.name})
 
         return results

--- a/tests/expected_json/arbitrary_send.arbitrary-send.json
+++ b/tests/expected_json/arbitrary_send.arbitrary-send.json
@@ -5,7 +5,7 @@
         ],
         "contract": "Test",
         "filename": "tests/arbitrary_send.sol",
-        "func": "direct",
+        "function": "direct",
         "sourceMapping": [
             {
                 "filename": "tests/arbitrary_send.sol",
@@ -24,7 +24,7 @@
         ],
         "contract": "Test",
         "filename": "tests/arbitrary_send.sol",
-        "func": "indirect",
+        "function": "indirect",
         "sourceMapping": [
             {
                 "filename": "tests/arbitrary_send.sol",

--- a/tests/expected_json/backdoor.suicidal.json
+++ b/tests/expected_json/backdoor.suicidal.json
@@ -2,7 +2,7 @@
     {
         "contract": "C",
         "filename": "tests/backdoor.sol",
-        "func": "i_am_a_backdoor",
+        "function": "i_am_a_backdoor",
         "sourceMapping": {
             "filename": "tests/backdoor.sol",
             "length": 74,

--- a/tests/expected_json/external_function.external-function.json
+++ b/tests/expected_json/external_function.external-function.json
@@ -2,7 +2,7 @@
     {
         "contract": "ContractWithFunctionNotCalled",
         "filename": "tests/external_function.sol",
-        "func": "funcNotCalled",
+        "function": "funcNotCalled",
         "sourceMapping": {
             "filename": "tests/external_function.sol",
             "length": 40,
@@ -18,7 +18,7 @@
     {
         "contract": "ContractWithFunctionNotCalled",
         "filename": "tests/external_function.sol",
-        "func": "funcNotCalled2",
+        "function": "funcNotCalled2",
         "sourceMapping": {
             "filename": "tests/external_function.sol",
             "length": 41,
@@ -34,7 +34,7 @@
     {
         "contract": "ContractWithFunctionNotCalled",
         "filename": "tests/external_function.sol",
-        "func": "funcNotCalled3",
+        "function": "funcNotCalled3",
         "sourceMapping": {
             "filename": "tests/external_function.sol",
             "length": 41,
@@ -50,7 +50,7 @@
     {
         "contract": "ContractWithFunctionNotCalled2",
         "filename": "tests/external_function.sol",
-        "func": "funcNotCalled",
+        "function": "funcNotCalled",
         "sourceMapping": {
             "filename": "tests/external_function.sol",
             "length": 304,

--- a/tests/expected_json/inline_assembly_contract.assembly.json
+++ b/tests/expected_json/inline_assembly_contract.assembly.json
@@ -2,7 +2,7 @@
     {
         "contract": "GetCode",
         "filename": "tests/inline_assembly_contract.sol",
-        "function_name": "at",
+        "function": "at",
         "sourceMapping": [
             {
                 "filename": "tests/inline_assembly_contract.sol",

--- a/tests/expected_json/inline_assembly_library.assembly.json
+++ b/tests/expected_json/inline_assembly_library.assembly.json
@@ -2,7 +2,7 @@
     {
         "contract": "VectorSum",
         "filename": "tests/inline_assembly_library.sol",
-        "function_name": "sumAsm",
+        "function": "sumAsm",
         "sourceMapping": [
             {
                 "filename": "tests/inline_assembly_library.sol",
@@ -21,7 +21,7 @@
     {
         "contract": "VectorSum",
         "filename": "tests/inline_assembly_library.sol",
-        "function_name": "sumPureAsm",
+        "function": "sumPureAsm",
         "sourceMapping": [
             {
                 "filename": "tests/inline_assembly_library.sol",

--- a/tests/expected_json/low_level_calls.low-level-calls.json
+++ b/tests/expected_json/low_level_calls.low-level-calls.json
@@ -2,7 +2,7 @@
     {
         "contract": "Sender",
         "filename": "tests/low_level_calls.sol",
-        "function_name": "send",
+        "function": "send",
         "sourceMapping": [
             {
                 "filename": "tests/low_level_calls.sol",

--- a/tests/expected_json/reentrancy.reentrancy.json
+++ b/tests/expected_json/reentrancy.reentrancy.json
@@ -5,7 +5,7 @@
         ],
         "contract": "Reentrancy",
         "filename": "tests/reentrancy.sol",
-        "function_name": "withdrawBalance",
+        "function": "withdrawBalance",
         "send_eth": [
             "! (msg.sender.call.value(userBalance[msg.sender])())"
         ],

--- a/tests/expected_json/tx_origin.tx-origin.json
+++ b/tests/expected_json/tx_origin.tx-origin.json
@@ -2,7 +2,7 @@
     {
         "contract": "TxOrigin",
         "filename": "tests/tx_origin.sol",
-        "function_name": "bug0",
+        "function": "bug0",
         "sourceMapping": [
             {
                 "filename": "tests/tx_origin.sol",
@@ -18,7 +18,7 @@
     {
         "contract": "TxOrigin",
         "filename": "tests/tx_origin.sol",
-        "function_name": "bug2",
+        "function": "bug2",
         "sourceMapping": [
             {
                 "filename": "tests/tx_origin.sol",


### PR DESCRIPTION
## Current situation

json output of the different detectors return different property name for the name of the function in which something was detected: `func`, `function`, `function_name`, and `funcs`, `functions`.

## Wanted Situation

they all use the same property name: `function` and `functions`.