### PR TITLE
Add support for executing truffle locally

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -59,7 +59,7 @@ def _process(slither, detector_classes, printer_classes):
     return results, analyzed_contracts_count
 
 def process_truffle(dirname, args, detector_classes, printer_classes):
-    cmd = ['truffle','compile']
+    cmd =  ['npx','truffle','compile'] if args.truffle_local else ['truffle','compile']
     logger.info('truffle compile running...')
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -356,6 +356,10 @@ def parse_args(detector_classes, printer_classes):
                             help='Export results as JSON',
                             action='store',
                             default=None)
+    group_misc.add_argument('--truffle-local',
+                            help='Truffle local execution with npx',
+                            action='store_true',
+                            default=False)
 
 
 


### PR DESCRIPTION
Adds support to be able to run `truffle compile` without having to install it globally.

Closes #105 

Truffle being used by default:

```
matt@delleite:contracts/ (master*) $ slither .                                                                                                                [18:11:18]
INFO:Slither:truffle compile running...
ERROR:root:Error in .
ERROR:root:Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/slither_analyzer-0.3.1-py3.7.egg/slither/__main__.py", line 229, in main_impl
    (results, number_contracts) = process_truffle(filename, args, detector_classes, printer_classes)
  File "/usr/lib/python3.7/site-packages/slither_analyzer-0.3.1-py3.7.egg/slither/__main__.py", line 64, in process_truffle
    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.7/subprocess.py", line 769, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.7/subprocess.py", line 1516, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'truffle': 'truffle'
```

With truffle locally (--truffle-local):
```
matt@delleite:contracts/ (master*) $ slither . --truffle-local                                                                                                [18:11:57]
INFO:Slither:truffle compile running...                                                                                                                                         
INFO:Slither:                                                                                                                                                                   
INFO:Detectors: 
....
INFO:Slither:. analyzed (10 contracts), 48 result(s) found