### PR TITLE
[WIP] Expose immediate base contracts and base constructors

### DIFF
--- a/scripts/json_diff.py
+++ b/scripts/json_diff.py
@@ -7,10 +7,10 @@ if len(sys.argv) !=3:
     print('Usage: python json_diff.py 1.json 2.json')
     exit(-1)
 
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], encoding='utf8') as f:
     d1 = json.load(f)
 
-with open(sys.argv[2]) as f:
+with open(sys.argv[2], encoding='utf8') as f:
     d2 = json.load(f)
 
 

--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -84,7 +84,7 @@ def process_files(filenames, args, detector_classes, printer_classes):
     all_contracts = []
 
     for filename in filenames:
-        with open(filename) as f:
+        with open(filename, encoding='utf8') as f:
             contract_loaded = json.load(f)
             all_contracts.append(contract_loaded['ast'])
 
@@ -93,7 +93,7 @@ def process_files(filenames, args, detector_classes, printer_classes):
 
 
 def output_json(results, filename):
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf8') as f:
         json.dump(results, f)
 
 

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -121,14 +121,18 @@ class Contract(ChildSlither, SourceMapping):
             executed, following the c3 linearization
             Return None if there is no constructor.
         '''
-        cst = next((func for func in self.functions if func.is_constructor and func.contract == self), None)
+        cst = self.constructor_not_inherited
         if cst:
             return cst
         for inherited_contract in self.inheritance:
-            cst = inherited_contract.constructor
+            cst = inherited_contract.constructor_not_inherited
             if cst:
                 return cst
         return None
+
+    @property
+    def constructor_not_inherited(self):
+        return next((func for func in self.functions if func.is_constructor and func.contract == self), None)
 
     @property
     def constructors(self):

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -20,6 +20,7 @@ class Contract(ChildSlither, SourceMapping):
         self._name = None
         self._id = None
         self._inheritance = []
+        self._immediate_inheritance = []
 
         self._enums = {}
         self._structures = {}
@@ -61,14 +62,22 @@ class Contract(ChildSlither, SourceMapping):
         return list(self._inheritance)
 
     @property
+    def immediate_inheritance(self):
+        '''
+            list(Contract): List of contracts immediately inherited from (fathers). Order: order of declaration.
+        '''
+        return list(self._immediate_inheritance)
+
+    @property
     def inheritance_reverse(self):
         '''
             list(Contract): Inheritance list. Order: the last elem is the first father to be executed
         '''
         return reversed(self._inheritance)
 
-    def setInheritance(self, inheritance):
+    def setInheritance(self, inheritance, immediate_inheritance):
         self._inheritance = inheritance
+        self._immediate_inheritance = immediate_inheritance
 
     @property
     def derived_contracts(self):

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -21,6 +21,7 @@ class Contract(ChildSlither, SourceMapping):
         self._id = None
         self._inheritance = []
         self._immediate_inheritance = []
+        self._base_constructor_contracts_called = []
 
         self._enums = {}
         self._structures = {}
@@ -75,9 +76,10 @@ class Contract(ChildSlither, SourceMapping):
         '''
         return reversed(self._inheritance)
 
-    def setInheritance(self, inheritance, immediate_inheritance):
+    def setInheritance(self, inheritance, immediate_inheritance, called_base_constructor_contracts):
         self._inheritance = inheritance
         self._immediate_inheritance = immediate_inheritance
+        self._base_constructor_contracts_called = called_base_constructor_contracts
 
     @property
     def derived_contracts(self):
@@ -139,6 +141,29 @@ class Contract(ChildSlither, SourceMapping):
             list(Functions): List of public and external functions
         '''
         return [f for f in self.functions if f.visibility in ['public', 'external']]
+
+    @property
+    def base_constructors_called(self):
+        """
+            list(Function): List of the base constructors invoked by this contract definition, not via
+                            this contract's constructor definition.
+
+                            NOTE: Base constructors can also be called from the constructor definition!
+        """
+        return [c.constructor for c in self._base_constructor_contracts_called if c.constructor]
+
+    @property
+    def all_base_constructors_called(self):
+        """
+            list(Function): List of the base constructors invoked by this contract definition, or the
+                            underlying constructor definition. They should be in order of declaration,
+                            starting first with contract definition's base constructor calls, then the
+                            constructor definition's base constructor calls.
+
+                            NOTE: Duplicates may occur if the same base contracts are called in both
+                            the contract and constructor definition.
+        """
+        return self.base_constructors_called + self.constructor.base_constructors_called
 
     @property
     def modifiers(self):

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -115,6 +115,10 @@ class Contract(ChildSlither, SourceMapping):
         return next((func for func in self.functions if func.is_constructor), None)
 
     @property
+    def constructor_not_inherited(self):
+        return next((func for func in self.functions if func.is_constructor and func.contract == self), None)
+
+    @property
     def functions(self):
         '''
             list(Function): List of the functions
@@ -152,7 +156,7 @@ class Contract(ChildSlither, SourceMapping):
                             parenthesis) will not be included.
         """
         # This is a list of contracts internally, so we convert it to a list of constructor functions.
-        return [c.constructor for c in self._explicit_base_constructor_calls if c.constructor]
+        return [c.constructor_not_inherited for c in self._explicit_base_constructor_calls if c.constructor_not_inherited]
 
     @property
     def modifiers(self):
@@ -233,6 +237,7 @@ class Contract(ChildSlither, SourceMapping):
         all_state_variables_written = [f.all_state_variables_written() for f in self.functions + self.modifiers]
         all_state_variables_written = [item for sublist in all_state_variables_written for item in sublist]
         return list(set(all_state_variables_written))
+
     @property
     def all_state_variables_read(self):
         '''

--- a/slither/core/declarations/contract.py
+++ b/slither/core/declarations/contract.py
@@ -21,7 +21,7 @@ class Contract(ChildSlither, SourceMapping):
         self._id = None
         self._inheritance = []
         self._immediate_inheritance = []
-        self._base_constructor_contracts_called = []
+        self._explicit_base_constructor_calls = []
 
         self._enums = {}
         self._structures = {}
@@ -79,7 +79,7 @@ class Contract(ChildSlither, SourceMapping):
     def setInheritance(self, inheritance, immediate_inheritance, called_base_constructor_contracts):
         self._inheritance = inheritance
         self._immediate_inheritance = immediate_inheritance
-        self._base_constructor_contracts_called = called_base_constructor_contracts
+        self._explicit_base_constructor_calls = called_base_constructor_contracts
 
     @property
     def derived_contracts(self):
@@ -143,27 +143,16 @@ class Contract(ChildSlither, SourceMapping):
         return [f for f in self.functions if f.visibility in ['public', 'external']]
 
     @property
-    def base_constructors_called(self):
+    def explicit_base_constructor_calls(self):
         """
-            list(Function): List of the base constructors invoked by this contract definition, not via
-                            this contract's constructor definition.
+            list(Function): List of the base constructors called explicitly by this contract definition.
 
-                            NOTE: Base constructors can also be called from the constructor definition!
+                            Base constructors called by any constructor definition will not be included.
+                            Base constructors implicitly called by the contract definition (without
+                            parenthesis) will not be included.
         """
-        return [c.constructor for c in self._base_constructor_contracts_called if c.constructor]
-
-    @property
-    def all_base_constructors_called(self):
-        """
-            list(Function): List of the base constructors invoked by this contract definition, or the
-                            underlying constructor definition. They should be in order of declaration,
-                            starting first with contract definition's base constructor calls, then the
-                            constructor definition's base constructor calls.
-
-                            NOTE: Duplicates may occur if the same base contracts are called in both
-                            the contract and constructor definition.
-        """
-        return self.base_constructors_called + self.constructor.base_constructors_called
+        # This is a list of contracts internally, so we convert it to a list of constructor functions.
+        return [c.constructor for c in self._explicit_base_constructor_calls if c.constructor]
 
     @property
     def modifiers(self):

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -56,7 +56,7 @@ class Function(ChildContract, SourceMapping):
         self._expression_calls = []
         self._expression_modifiers = []
         self._modifiers = []
-        self._base_constructor_contracts_called = []
+        self._explicit_base_constructor_calls = []
         self._payable = False
         self._contains_assembly = False
 
@@ -200,14 +200,15 @@ class Function(ChildContract, SourceMapping):
         return list(self._modifiers)
 
     @property
-    def base_constructors_called(self):
+    def explicit_base_constructor_calls(self):
         """
-            list(Function): List of the base constructors invoked by this presumed constructor by definition, not via
-                            calls within the function body.
+            list(Function): List of the base constructors called explicitly by this presumed constructor definition.
 
-                            NOTE: Base constructors can also be called from the contract definition!
+                            Base constructors implicitly or explicitly called by the contract definition will not be
+                            included.
         """
-        return [c.constructor for c in self._base_constructor_contracts_called if c.constructor]
+        # This is a list of contracts internally, so we convert it to a list of constructor functions.
+        return [c.constructor for c in self._explicit_base_constructor_calls if c.constructor]
 
     def __str__(self):
         return self._name

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -56,6 +56,7 @@ class Function(ChildContract, SourceMapping):
         self._expression_calls = []
         self._expression_modifiers = []
         self._modifiers = []
+        self._base_constructor_contracts_called = []
         self._payable = False
         self._contains_assembly = False
 
@@ -197,6 +198,14 @@ class Function(ChildContract, SourceMapping):
             list(Modifier): List of the modifiers
         """
         return list(self._modifiers)
+
+    @property
+    def base_constructors_called(self):
+        """
+            list(Function): List of the base constructors invoked by this presumed constructor by definition, not via
+                            calls within the function body.
+        """
+        return [c.constructor for c in self._base_constructor_contracts_called if c.constructor]
 
     def __str__(self):
         return self._name

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -204,6 +204,8 @@ class Function(ChildContract, SourceMapping):
         """
             list(Function): List of the base constructors invoked by this presumed constructor by definition, not via
                             calls within the function body.
+
+                            NOTE: Base constructors can also be called from the contract definition!
         """
         return [c.constructor for c in self._base_constructor_contracts_called if c.constructor]
 

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -208,7 +208,7 @@ class Function(ChildContract, SourceMapping):
                             included.
         """
         # This is a list of contracts internally, so we convert it to a list of constructor functions.
-        return [c.constructor for c in self._explicit_base_constructor_calls if c.constructor]
+        return [c.constructor_not_inherited for c in self._explicit_base_constructor_calls if c.constructor_not_inherited]
 
     def __str__(self):
         return self._name

--- a/slither/core/declarations/function.py
+++ b/slither/core/declarations/function.py
@@ -654,7 +654,7 @@ class Function(ChildContract, SourceMapping):
         Args:
             filename (str)
         """
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf8') as f:
             f.write('digraph{\n')
             for node in self.nodes:
                 f.write('{}[label="{}"];\n'.format(node.node_id, str(node)))
@@ -670,7 +670,7 @@ class Function(ChildContract, SourceMapping):
             filename (str)
         """
         from slither.core.cfg.node import NodeType
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf8') as f:
             f.write('digraph{\n')
             for node in self.nodes:
                 label = 'Node Type: {} {}\n'.format(NodeType.str(node.type), node.node_id)
@@ -696,7 +696,7 @@ class Function(ChildContract, SourceMapping):
             if node.dominance_frontier:
                 desc += '\ndominance frontier: {}'.format([n.node_id for n in node.dominance_frontier])
             return desc
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf8') as f:
             f.write('digraph{\n')
             for node in self.nodes:
                 f.write('{}[label="{}"];\n'.format(node.node_id, description(node)))

--- a/slither/core/solidity_types/array_type.py
+++ b/slither/core/solidity_types/array_type.py
@@ -1,12 +1,15 @@
 from slither.core.variables.variable import Variable
 from slither.core.solidity_types.type import Type
 from slither.core.expressions.expression import Expression
+from slither.core.expressions import Literal
 
 class ArrayType(Type):
 
     def __init__(self, t, length):
         assert isinstance(t, Type)
         if length:
+            if isinstance(length, int):
+                length = Literal(length)
             assert isinstance(length, Expression)
         super(ArrayType, self).__init__()
         self._type = t

--- a/slither/printers/call/call_graph.py
+++ b/slither/printers/call/call_graph.py
@@ -145,7 +145,7 @@ class PrinterCallGraph(AbstractPrinter):
 
         self.info(f'Call Graph: {filename}')
 
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf8') as f:
             f.write('\n'.join([
                 'strict digraph {',
                 self._render_internal_calls(),

--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -117,7 +117,7 @@ class PrinterInheritanceGraph(AbstractPrinter):
             filename += ".dot"
         info = 'Inheritance Graph: ' + filename
         self.info(info)
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf8') as f:
             f.write('digraph{\n')
             for c in self.contracts:
                 f.write(self._summary(c))

--- a/slither/slither.py
+++ b/slither/slither.py
@@ -117,7 +117,7 @@ class Slither(SlitherSolc):
             raise Exception('Incorrect file format')
 
         if is_ast_file:
-            with open(filename) as astFile:
+            with open(filename, encoding='utf8') as astFile:
                 stdout = astFile.read()
                 if not stdout:
                     logger.info('Empty AST file: %s', filename)

--- a/slither/slithir/operations/internal_dynamic_call.py
+++ b/slither/slithir/operations/internal_dynamic_call.py
@@ -17,6 +17,10 @@ class InternalDynamicCall(Call, OperationWithLValue):
         self._function_type = function_type
         self._lvalue = lvalue
 
+        self._callid = None # only used if gas/value != 0
+        self._call_value = None
+        self._call_gas = None
+
     @property
     def read(self):
         return self._unroll(self.arguments) + [self.function]
@@ -29,16 +33,49 @@ class InternalDynamicCall(Call, OperationWithLValue):
     def function_type(self):
         return self._function_type
 
+    @property
+    def call_value(self):
+        return self._call_value
+
+    @call_value.setter
+    def call_value(self, v):
+        self._call_value = v
+
+
+    @property
+    def call_gas(self):
+        return self._call_gas
+
+    @call_gas.setter
+    def call_gas(self, v):
+        self._call_gas = v
+
+    @property
+    def call_id(self):
+        return self._callid
+
+    @call_id.setter
+    def call_id(self, c):
+        self._callid = c
+
     def __str__(self):
+        value = ''
+        gas = ''
         args = [str(a) for a in self.arguments]
+        if self.call_value:
+            value = 'value:{}'.format(self.call_value)
+        if self.call_gas:
+            gas = 'gas:{}'.format(self.call_gas)
         if not self.lvalue:
             lvalue = ''
         elif isinstance(self.lvalue.type, (list,)):
             lvalue = '{}({}) = '.format(self.lvalue, ','.join(str(x) for x in self.lvalue.type))
         else:
             lvalue = '{}({}) = '.format(self.lvalue, self.lvalue.type)
-        txt = '{}INTERNAL_DYNAMIC_CALL {}({})'
+        txt = '{}INTERNAL_DYNAMIC_CALL {}({}) {} {}'
         return txt.format(lvalue,
                           self.function.name,
-                          ','.join(args))
+                          ','.join(args),
+                          value,
+                          gas)
 

--- a/slither/solc_parsing/declarations/contract.py
+++ b/slither/solc_parsing/declarations/contract.py
@@ -91,6 +91,18 @@ class ContractSolc04(Contract):
         self.linearizedBaseContracts = attributes['linearizedBaseContracts']
         self.fullyImplemented = attributes['fullyImplemented']
 
+        # Parse base contracts (immediate, non-linearized)
+        self.baseContracts = []
+        if self.is_compact_ast:
+            if 'baseContracts' in attributes:
+                for base_contract in attributes['baseContracts']:
+                    if base_contract['nodeType'] == 'InheritanceSpecifier':
+                        if 'baseName' in base_contract and 'referencedDeclaration' in base_contract['baseName']:
+                            self.baseContracts.append(base_contract['baseName']['referencedDeclaration'])
+        else:
+            # TODO: Parse from legacy-ast. 'baseContracts' is unreliable here. Possibly use 'children'.
+            pass
+
         # trufle does some re-mapping of id
         if 'baseContracts' in self._data:
             for elem in self._data['baseContracts']:

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -314,7 +314,11 @@ class FunctionSolc(Function):
         node_endDoWhile = self._new_node(NodeType.ENDLOOP, doWhilestatement['src'])
 
         link_nodes(node, node_startDoWhile)
-        link_nodes(node_startDoWhile, node_condition.sons[0])
+        # empty block, loop from the start to the condition
+        if not node_condition.sons:
+            link_nodes(node_startDoWhile, node_condition)
+        else:
+            link_nodes(node_startDoWhile, node_condition.sons[0])
         link_nodes(statement, node_condition)
         link_nodes(node_condition, node_endDoWhile)
         return node_endDoWhile
@@ -834,6 +838,10 @@ class FunctionSolc(Function):
         for node in self.nodes:
             node.analyze_expressions(self)
 
+        self._filter_ternary()
+        self._remove_alone_endif()
+
+    def _filter_ternary(self):
         ternary_found = True
         while ternary_found:
             ternary_found = False
@@ -848,7 +856,6 @@ class FunctionSolc(Function):
                     self.split_ternary_node(node, condition, true_expr, false_expr)
                     ternary_found = True
                     break
-        self._remove_alone_endif()
 
     def get_last_ssa_state_variables_instances(self):
         if not self.is_implemented:

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -773,7 +773,7 @@ class FunctionSolc(Function):
             if isinstance(m, Function):
                 self._modifiers.append(m)
             elif isinstance(m, Contract):
-                self._base_constructor_contracts_called.append(m)
+                self._explicit_base_constructor_calls.append(m)
 
 
     def analyze_params(self):

--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -26,6 +26,7 @@ from slither.solc_parsing.variables.variable_declaration import \
 from slither.utils.expression_manipulations import SplitTernaryExpression
 from slither.visitors.expression.export_values import ExportValues
 from slither.visitors.expression.has_conditional import HasConditional
+from slither.core.declarations.contract import Contract
 
 logger = logging.getLogger("FunctionSolc")
 
@@ -768,7 +769,11 @@ class FunctionSolc(Function):
     def _parse_modifier(self, modifier):
         m = parse_expression(modifier, self)
         self._expression_modifiers.append(m)
-        self._modifiers += [m for m in ExportValues(m).result() if isinstance(m, Function)]
+        for m in ExportValues(m).result():
+            if isinstance(m, Function):
+                self._modifiers.append(m)
+            elif isinstance(m, Contract):
+                self._base_constructor_contracts_called.append(m)
 
 
     def analyze_params(self):

--- a/slither/solc_parsing/declarations/modifier.py
+++ b/slither/solc_parsing/declarations/modifier.py
@@ -59,6 +59,9 @@ class ModifierSolc(Modifier, FunctionSolc):
         for node in self.nodes:
             node.analyze_expressions(self)
 
+        self._filter_ternary()
+        self._remove_alone_endif()
+
         self._analyze_read_write()
         self._analyze_calls()
 

--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -241,7 +241,10 @@ def convert_subdenomination(value, sub):
     if sub is None:
         return value
     # to allow 0.1 ether conversion
-    value = float(value)
+    if value[0:2] == "0x":
+        value = float(int(value, 16))
+    else:
+        value = float(value)
     if sub == 'wei':
         return int(value)
     if sub == 'szabo':
@@ -548,6 +551,8 @@ def parse_expression(expression, caller_context):
                     array_type = parse_type(UnknownType(type_name['name']), caller_context)
                 else:
                     array_type = parse_type(UnknownType(type_name['attributes']['name']), caller_context)
+            elif type_name[caller_context.get_key()] == 'FunctionTypeName':
+                array_type = parse_type(type_name, caller_context)
             else:
                 logger.error('Incorrect type array {}'.format(type_name))
                 exit(-1)

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -161,6 +161,7 @@ class SlitherSolc(Slither):
             # remove the first elem in linearizedBaseContracts as it is the contract itself
             ancestors = []
             fathers = []
+            father_constructors = []
             try:
                 # Resolve linearized base contracts.
                 for i in contract.linearizedBaseContracts[1:]:
@@ -175,13 +176,21 @@ class SlitherSolc(Slither):
                         fathers.append(self.get_contract_from_name(contract.remapping[i]))
                     else:
                         fathers.append(self._contracts_by_id[i])
+
+                # Resolve immediate base constructor calls
+                for i in contract.baseConstructorContractsCalled:
+                    if i in contract.remapping:
+                        father_constructors.append(self.get_contract_from_name(contract.remapping[i]))
+                    else:
+                        father_constructors.append(self._contracts_by_id[i])
+
             except KeyError:
                 logger.error(red('A contract was not found, it is likely that your codebase contains muliple contracts with the same name'))
                 logger.error(red('Truffle does not handle this case during compilation'))
                 logger.error(red('Please read https://github.com/trailofbits/slither/wiki#keyerror-or-nonetype-error'))
                 logger.error(red('And update your code to remove the duplicate'))
                 exit(-1)
-            contract.setInheritance(ancestors, fathers)
+            contract.setInheritance(ancestors, fathers, father_constructors)
 
         contracts_to_be_analyzed = self.contracts
 

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -159,9 +159,18 @@ class SlitherSolc(Slither):
         # Update of the inheritance 
         for contract in self._contractsNotParsed:
             # remove the first elem in linearizedBaseContracts as it is the contract itself
+            ancestors = []
             fathers = []
             try:
+                # Resolve linearized base contracts.
                 for i in contract.linearizedBaseContracts[1:]:
+                    if i in contract.remapping:
+                        ancestors.append(self.get_contract_from_name(contract.remapping[i]))
+                    else:
+                        ancestors.append(self._contracts_by_id[i])
+
+                # Resolve immediate base contracts
+                for i in contract.baseContracts:
                     if i in contract.remapping:
                         fathers.append(self.get_contract_from_name(contract.remapping[i]))
                     else:
@@ -172,7 +181,7 @@ class SlitherSolc(Slither):
                 logger.error(red('Please read https://github.com/trailofbits/slither/wiki#keyerror-or-nonetype-error'))
                 logger.error(red('And update your code to remove the duplicate'))
                 exit(-1)
-            contract.setInheritance(fathers)
+            contract.setInheritance(ancestors, fathers)
 
         contracts_to_be_analyzed = self.contracts
 

--- a/slither/solc_parsing/slitherSolc.py
+++ b/slither/solc_parsing/slitherSolc.py
@@ -63,7 +63,7 @@ class SlitherSolc(Slither):
         if 'sourcePaths' in data_loaded:
             for sourcePath in data_loaded['sourcePaths']:
                 if os.path.isfile(sourcePath):
-                    with open(sourcePath) as f:
+                    with open(sourcePath, encoding='utf8') as f:
                         source_code = f.read()
                     self.source_code[sourcePath] = source_code
 
@@ -126,13 +126,13 @@ class SlitherSolc(Slither):
 
         self._source_units[sourceUnit] = name
         if os.path.isfile(name) and not name in self.source_code:
-            with open(name) as f:
+            with open(name, encoding='utf8') as f:
                 source_code = f.read()
             self.source_code[name] = source_code
         else:
             lib_name = os.path.join('node_modules', name)
             if os.path.isfile(lib_name) and not name in self.source_code:
-                with open(lib_name) as f:
+                with open(lib_name, encoding='utf8') as f:
                     source_code = f.read()
                 self.source_code[name] = source_code
 

--- a/slither/visitors/slithir/expression_to_slithir.py
+++ b/slither/visitors/slithir/expression_to_slithir.py
@@ -160,6 +160,14 @@ class ExpressionToSlithIR(ExpressionVisitor):
         left = get(expression.expression_left)
         right = get(expression.expression_right)
         val = ReferenceVariable(self._node)
+        # access to anonymous array
+        # such as [0,1][x]
+        if isinstance(left, list):
+            init_array_val = TemporaryVariable(self._node)
+            init_array_right = left
+            left = init_array_val
+            operation = InitArray(init_array_right, init_array_val)
+            self._result.append(operation)
         operation = Index(val, left, right, expression.type)
         self._result.append(operation)
         set_val(expression, val)


### PR DESCRIPTION
This pull request aims to resolve #131 . It aims to provide the immediate base contracts of a given contract in the correct order of declaration via `contract.immediate_inheritance`. This contrasts to the existing provided `contract.inheritance` which provides a flattened, linearized base contract list (all ancestors in the inheritance chain, immediate and not).