### PR TITLE
Add hexadecimal support for subdenominations

### DIFF
--- a/slither/solc_parsing/expressions/expression_parsing.py
+++ b/slither/solc_parsing/expressions/expression_parsing.py
@@ -241,7 +241,10 @@ def convert_subdenomination(value, sub):
     if sub is None:
         return value
     # to allow 0.1 ether conversion
-    value = float(value)
+    if value[0:2] == "0x":
+        value = float(int(value, 16))
+    else:
+        value = float(value)
     if sub == 'wei':
         return int(value)
     if sub == 'szabo':


### PR DESCRIPTION
This pull request aims to resolve #134 . It adds a switch for parsing hexadecimal sub-denominations in contracts.