### PR TITLE
Expose "indexed" attribute on event parameters

### DIFF
--- a/slither/core/variables/event_variable.py
+++ b/slither/core/variables/event_variable.py
@@ -1,5 +1,16 @@
 from .variable import Variable
 from slither.core.children.child_event import ChildEvent
 
-class EventVariable(ChildEvent, Variable): pass
+class EventVariable(ChildEvent, Variable):
+    def __init__(self):
+        super(EventVariable, self).__init__()
+        self._indexed = False
+
+    @property
+    def indexed(self):
+        """
+        Indicates whether the event variable is indexed in the bloom filter.
+        :return: Returns True if the variable is indexed in bloom filter, False otherwise.
+        """
+        return self._indexed
 

--- a/slither/solc_parsing/variables/event_variable.py
+++ b/slither/solc_parsing/variables/event_variable.py
@@ -2,4 +2,18 @@
 from .variable_declaration import VariableDeclarationSolc
 from slither.core.variables.event_variable import EventVariable
 
-class EventVariableSolc(VariableDeclarationSolc, EventVariable): pass
+class EventVariableSolc(VariableDeclarationSolc, EventVariable):
+
+    def _analyze_variable_attributes(self, attributes):
+        """
+        Analyze event variable attributes
+        :param attributes: The event variable attributes to parse.
+        :return: None
+        """
+
+        # Check for the indexed attribute
+        if 'indexed' in attributes:
+            self._indexed = attributes['indexed']
+
+        super(EventVariableSolc, self)._analyze_variable_attributes(attributes)
+


### PR DESCRIPTION
This pull request aims to provide access to the 'indexed' attribute on event parameters, such that detectors can know if certain event parameters are indexed in the bloom filter. 

Indexed event parameters are included in a transaction's bloom filter in order for external tools to quickly look for transactions which contained that data (a specific receiving address, etc). This is especially important when considering that many tools expect events in the ERC20 specification to index certain parameters, and will miss an event log's inclusion in a set if the bloom filter returns a "not-indexed" result.

Exposing this attribute may be useful to detectors which check contracts that implement ERC specifications are well formed.