### PR TITLE
Updates to colorization (disable colorization + windows support)

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -17,6 +17,7 @@ from slither.printers.abstract_printer import AbstractPrinter
 from slither.slither import Slither
 from slither.utils.colors import red
 from slither.utils.command_line import output_to_markdown, output_detectors, output_printers, output_detectors_json, output_wiki
+from slither.utils.colors import set_colorization_enabled
 
 logging.basicConfig()
 logger = logging.getLogger("Slither")
@@ -229,6 +230,9 @@ def main_impl(all_detector_classes, all_printer_classes):
     """
     args = parse_args(all_detector_classes, all_printer_classes)
 
+    # Set colorization option
+    set_colorization_enabled(not args.disable_color)
+
     printer_classes = choose_printers(args, all_printer_classes)
     detector_classes = choose_detectors(args, all_detector_classes)
 
@@ -395,6 +399,10 @@ def parse_args(detector_classes, printer_classes):
     group_misc.add_argument('--truffle-version',
                             help='Use a local Truffle version (with npx)',
                             action='store',
+                            default=False)
+    group_misc.add_argument('--disable-color',
+                            help='Disable output colorization',
+                            action='store_true',
                             default=False)
 
 

--- a/slither/utils/colors.py
+++ b/slither/utils/colors.py
@@ -2,6 +2,7 @@ from functools import partial
 
 
 class Colors:
+    COLORIZATION_ENABLED = True
     RED = '\033[91m'
     GREEN = '\033[92m'
     YELLOW = '\033[93m'
@@ -11,7 +12,14 @@ class Colors:
 
 
 def colorize(color, txt):
-    return '{}{}{}'.format(color, txt, Colors.END)
+    if Colors.COLORIZATION_ENABLED:
+        return '{}{}{}'.format(color, txt, Colors.END)
+    else:
+        return txt
+
+
+def set_colorization_enabled(enabled):
+    Colors.COLORIZATION_ENABLED = enabled
 
 
 green = partial(colorize, Colors.GREEN)

--- a/slither/utils/colors.py
+++ b/slither/utils/colors.py
@@ -32,6 +32,7 @@ def enable_windows_virtual_terminal_sequences():
     virtual_terminal_flag = 0x04  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
 
     # Obtain our stdout/stderr handles.
+    # Reference: https://docs.microsoft.com/en-us/windows/console/getstdhandle
     handle_stdout = kernel32.GetStdHandle(-11)
     handle_stderr = kernel32.GetStdHandle(-12)
 

--- a/slither/utils/colors.py
+++ b/slither/utils/colors.py
@@ -1,8 +1,9 @@
 from functools import partial
+import platform
 
 
 class Colors:
-    COLORIZATION_ENABLED = True
+    COLORIZATION_ENABLED = False
     RED = '\033[91m'
     GREEN = '\033[92m'
     YELLOW = '\033[93m'
@@ -18,8 +19,54 @@ def colorize(color, txt):
         return txt
 
 
+def enable_windows_virtual_terminal_sequences():
+    """
+    Sets the appropriate flags to enable virtual terminal sequences in a Windows command prompt.
+    Reference: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+    """
+
+    import ctypes
+    from ctypes.wintypes import DWORD, HANDLE
+
+    kernel32 = ctypes.windll.kernel32
+    virtual_terminal_flag = 0x04  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+
+    # Obtain our stdout/stderr handles.
+    handle_stdout = kernel32.GetStdHandle(-11)
+    handle_stderr = kernel32.GetStdHandle(-12)
+
+    # Loop for each stdout/stderr handle.
+    for current_handle in [handle_stdout, handle_stderr]:
+
+        # If we get a null handle, or fail any subsequent calls in this scope, we do not colorize any output.
+        if current_handle is None or current_handle == HANDLE(-1):
+            return False
+
+        # Try to obtain the current flags for the console.
+        current_mode = ctypes.wintypes.DWORD()
+        if not kernel32.GetConsoleMode(current_handle, ctypes.byref(current_mode)):
+            return False
+
+        # If the virtual terminal sequence processing is not yet enabled, we enable it.
+        if (current_mode.value & virtual_terminal_flag) == 0:
+            if not kernel32.SetConsoleMode(current_handle, current_mode.value | virtual_terminal_flag):
+                return False
+
+    return True
+
+
 def set_colorization_enabled(enabled):
-    Colors.COLORIZATION_ENABLED = enabled
+    """
+    Sets the enabled state of output colorization.
+    :param enabled: Boolean indicating whether output should be colorized.
+    :return: None
+    """
+    # If color is supposed to be enabled and this is windows, we have to enable console virtual terminal sequences:
+    if enabled and platform.system() == 'Windows':
+        Colors.COLORIZATION_ENABLED = enable_windows_virtual_terminal_sequences()
+    else:
+        # This is not windows so we can enable color immediately.
+        Colors.COLORIZATION_ENABLED = enabled
 
 
 green = partial(colorize, Colors.GREEN)

--- a/slither/utils/colors.py
+++ b/slither/utils/colors.py
@@ -25,10 +25,10 @@ def enable_windows_virtual_terminal_sequences():
     Reference: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
     """
 
-    import ctypes
+    from ctypes import windll, byref
     from ctypes.wintypes import DWORD, HANDLE
 
-    kernel32 = ctypes.windll.kernel32
+    kernel32 = windll.kernel32
     virtual_terminal_flag = 0x04  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
 
     # Obtain our stdout/stderr handles.
@@ -43,8 +43,8 @@ def enable_windows_virtual_terminal_sequences():
             return False
 
         # Try to obtain the current flags for the console.
-        current_mode = ctypes.wintypes.DWORD()
-        if not kernel32.GetConsoleMode(current_handle, ctypes.byref(current_mode)):
+        current_mode = DWORD()
+        if not kernel32.GetConsoleMode(current_handle, byref(current_mode)):
             return False
 
         # If the virtual terminal sequence processing is not yet enabled, we enable it.


### PR DESCRIPTION
This pull request adds a CLI argument to disable output colorization via `--disable-color`. It also adds support for colorization on Windows. Newer versions of Windows support ANSI color coding, although the mode is not set correctly by default, causing slither to output ANSI color codes despite Powershell/cmd ignoring them. 

This pull request checks if the platform is Windows and attempts to enable virtual terminal sequences to allow ANSI color codes to be interpreted. Any failure to enable virtual terminal sequences will fallback to disabling colorization.