### PR TITLE
Fix UserDefinedTypeName type parsing from names

### DIFF
--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -160,7 +160,7 @@ def parse_type(t, caller_context):
     elif t[key] == 'UserDefinedTypeName':
         if is_compact_ast:
             return _find_from_type_name(t['typeDescriptions']['typeString'], contract, contracts, structures, enums)
-        return _find_from_type_name(t['attributes'][key], contract, contracts, structures, enums)
+        return _find_from_type_name(t['attributes']['type'], contract, contracts, structures, enums)
 
     elif t[key] == 'ArrayTypeName':
         length = None

--- a/slither/solc_parsing/solidity_types/type_parsing.py
+++ b/slither/solc_parsing/solidity_types/type_parsing.py
@@ -160,7 +160,10 @@ def parse_type(t, caller_context):
     elif t[key] == 'UserDefinedTypeName':
         if is_compact_ast:
             return _find_from_type_name(t['typeDescriptions']['typeString'], contract, contracts, structures, enums)
-        return _find_from_type_name(t['attributes']['type'], contract, contracts, structures, enums)
+
+        # Determine if we have a type node (otherwise we use the name node, as some older solc did not have 'type').
+        type_name_key = 'type' if 'type' in t['attributes'] else key
+        return _find_from_type_name(t['attributes'][type_name_key], contract, contracts, structures, enums)
 
     elif t[key] == 'ArrayTypeName':
         length = None


### PR DESCRIPTION
This pull request resolves #160 and resolves #137 . It changes parsing on legacy-ast to use the `type` attribute instead of the `name` attribute, which provides more information, and was likely to be intended to be used from the start.

All relevant changes are in `type_parsing.py`. Please refer to the examples in both mentioned issues for examples of breaking behavior that has been fixed. 

A pass was done on over a thousand contracts to verify integrity of parsing. Further tests are always welcome, as this is a critical change.