### PR TITLE
Improve inheritance printers

### DIFF
--- a/slither/printers/inheritance/inheritance.py
+++ b/slither/printers/inheritance/inheritance.py
@@ -31,16 +31,26 @@ class PrinterInheritance(AbstractPrinter):
         if not self.contracts:
             return
 
-        info += blue('Child_Contract -> ') + green('Base_Contracts')
+        info += blue('Child_Contract -> ') + green('Immediate_Base_Contracts')
+        info += green(' [Not_Immediate_Base_Contracts]')
         for child in self.contracts:
             info += blue(f'\n+ {child.name}')
             if child.inheritance:
-                info += ' -> ' + green(", ".join(map(str, child.inheritance)))
+                immediate = child.immediate_inheritance
+                not_immediate = [i for i in child.inheritance if i not in immediate]
+                info += ' -> ' + green(", ".join(map(str, immediate)))
+                if not_immediate:
+                    info += ", ["+ green(", ".join(map(str, not_immediate))) + "]"
 
-        info += green('\n\nBase_Contract -> ') + blue('Child_Contracts')
+        info += green('\n\nBase_Contract -> ') + blue('Immediate_Child_Contracts')
+        info += blue(' [Not_Immediate_Child_Contracts]')
         for base in self.contracts:
             info += green(f'\n+ {base.name}')
             children = list(self._get_child_contracts(base))
             if children:
-                info += ' -> ' + blue(", ".join(map(str, children)))
+                immediate = [child for child in children if base in child.immediate_inheritance]
+                not_immediate = [child for child in children if not child in immediate]
+                info += ' -> ' + blue(", ".join(map(str, immediate)))
+                if not_immediate:
+                    info += ', [' + blue(", ".join(map(str, not_immediate))) + ']'
         self.info(info)

--- a/slither/printers/inheritance/inheritance_graph.py
+++ b/slither/printers/inheritance/inheritance_graph.py
@@ -59,7 +59,7 @@ class PrinterInheritanceGraph(AbstractPrinter):
         """
         ret = ''
         # Add arrows
-        for i in contract.inheritance:
+        for i in contract.immediate_inheritance:
             ret += '%s -> %s;\n' % (contract.name, i)
 
         # Functions


### PR DESCRIPTION
 - `inheritance-graph`: don't show redundant edges (close #157)
- `inheritance`: separate immediate/non immediate fathers/children:
![image](https://user-images.githubusercontent.com/13798342/52244519-ff583400-28ab-11e9-9ec0-0c464bcb5696.png)
