### PR TITLE
Fix shadowing-function detector and enhance inheritance-graph

### DIFF
--- a/slither/detectors/internal/c3_shadowing_internal.py
+++ b/slither/detectors/internal/c3_shadowing_internal.py
@@ -1,0 +1,88 @@
+"""
+Module detecting potential C3 linearization bugs (for internal use by printers)
+"""
+
+from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
+
+
+class C3LinearizationShadowingInternal(AbstractDetector):
+    """
+    C3 Linearization Shadowing
+    """
+
+    ARGUMENT = 'shadowing-c3-internal'
+    HELP = 'C3 Linearization Shadowing (Internal)'
+    IMPACT = DetectorClassification.HIGH
+    CONFIDENCE = DetectorClassification.HIGH
+
+    # This detector is not meant to be called as a generic detector
+    # It's only used by inheritances printers
+    WIKI = 'undefined'
+    WIKI_TITLE = 'undefined'
+    WIKI_DESCRIPTION = 'undefined'
+    WIKI_EXPLOIT_SCENARIO = 'undefined'
+    WIKI_RECOMMENDATION = 'undefined'
+
+
+    def detect_shadowing_definitions(self, contract):
+        """
+        Detects if a contract has two or more underlying contracts it inherits from which could potentially suffer from
+        C3 linearization shadowing bugs.
+
+        :param contract: The contract to check for potential C3 linearization shadowing within.
+        :return: A list of list of tuples: (contract, function), where each inner list describes colliding functions.
+        """
+
+        # Loop through all contracts, and all underlying functions.
+        results = {}
+        for i in range(0, len(contract.immediate_inheritance) - 1):
+            inherited_contract1 = contract.immediate_inheritance[i]
+
+            for function1 in inherited_contract1.functions_and_modifiers:
+                # If this function has already be handled or is unimplemented, we skip it
+                if function1.full_name in results or function1.is_constructor or not function1.is_implemented:
+                    continue
+
+                # Define our list of function instances which overshadow each other.
+                functions_matching = [(inherited_contract1, function1)]
+
+                # Loop again through other contracts and functions to compare to.
+                for x in range(i + 1, len(contract.immediate_inheritance)):
+                    inherited_contract2 = contract.immediate_inheritance[x]
+
+                    # Loop for each function in this contract
+                    for function2 in inherited_contract2.functions_and_modifiers:
+                        # Skip this function if it is the last function that was shadowed.
+                        if function2 == functions_matching[-1][1] or function2.is_constructor or not function2.is_implemented:
+                            continue
+
+                        # If this function does have the same full name, it is shadowing through C3 linearization.
+                        if function1.full_name == function2.full_name:
+                            functions_matching.append((inherited_contract2, function2))
+
+                # If we have more than one definition matching the same signature, we add it to the results.
+                if len(functions_matching) > 1:
+                    results[function1.full_name] = functions_matching
+
+        return list(results.values())
+
+    def detect(self):
+        """
+        Detect shadowing as a result of C3 linearization of contracts at the same inheritance depth-level.
+
+        Recursively visit the calls
+        Returns:
+            list: {'vuln', 'filename,'contract','func', 'shadows'}
+
+        """
+
+        results = []
+        for contract in self.contracts:
+            shadows = self.detect_shadowing_definitions(contract)
+            if shadows:
+                for shadow in shadows:
+                    for (shadow_contract, shadow_function) in shadow:
+                        results.append({'contract': shadow_function.contract.name,
+                                        'function': shadow_function.full_name})
+
+        return results

--- a/slither/detectors/internal/function_shadowing_internal.py
+++ b/slither/detectors/internal/function_shadowing_internal.py
@@ -6,15 +6,15 @@
 from slither.detectors.abstract_detector import AbstractDetector, DetectorClassification
 
 
-class ShadowingFunctionsDetection(AbstractDetector):
+class FunctionShadowingInternal(AbstractDetector):
     """
     Functions shadowing detection
     """
 
     vuln_name = "ShadowingFunctionContract"
 
-    ARGUMENT = 'shadowing-function'
-    HELP = 'Function Shadowing'
+    ARGUMENT = 'shadowing-function-internal'
+    HELP = 'Function Shadowing (Internal)'
     IMPACT = DetectorClassification.LOW
     CONFIDENCE = DetectorClassification.HIGH
 
@@ -31,7 +31,7 @@ class ShadowingFunctionsDetection(AbstractDetector):
         functions_declared = set([x.full_name for x in contract.functions_and_modifiers_not_inherited])
         ret = {}
         for father in contract.inheritance:
-            functions_declared_father = ([x.full_name for x in father.functions_and_modifiers_not_inherited])
+            functions_declared_father = ([x.full_name for x in father.functions_and_modifiers_not_inherited if x.is_implemented])
             inter = functions_declared.intersection(functions_declared_father)
             if inter:
                 ret[father] = inter

--- a/slither/detectors/shadowing/shadowing_functions.py
+++ b/slither/detectors/shadowing/shadowing_functions.py
@@ -28,10 +28,10 @@ class ShadowingFunctionsDetection(AbstractDetector):
 
 
     def detect_shadowing(self, contract):
-        functions_declared = set([x.full_name for x in contract.functions])
+        functions_declared = set([x.full_name for x in contract.functions_and_modifiers_not_inherited])
         ret = {}
         for father in contract.inheritance:
-            functions_declared_father = ([x.full_name for x in father.functions])
+            functions_declared_father = ([x.full_name for x in father.functions_and_modifiers_not_inherited])
             inter = functions_declared.intersection(functions_declared_father)
             if inter:
                 ret[father] = inter


### PR DESCRIPTION
This pull request aims to resolve #165 . It fixes the `shadowing-function` detector and extends/

**Changes:**
-Fixed an issue where the `shadowing-function` detector would return all inherited functions (even if not shadowed).
-Added an `internal` directory under `detectors` to house detectors which are not used for vulnerabilities, but as helpers throughout the program (such as for the `inheritance-graph` printer).
-Updated `inheritance-graph` printer to highlight all function collisions (shadowing + shadowed functions, not just shadowing).
-Updated `inheritance-graph` printer to consider modifier collisions (not just functions).
-Updated `inheritance-graph` printer to highlight collisions via C3 linearization (and added a relevant `internal` detector to help with detection of all c3 linearization function collisions).

Note: Unimplemented functions and their later implementations will not count as collisions currently (and will not be highlighted). This can easily be changed if desired.