### PR TITLE
Fix missing loop components on legacy-ast

### DIFF
--- a/slither/solc_parsing/declarations/function.py
+++ b/slither/solc_parsing/declarations/function.py
@@ -257,14 +257,26 @@ class FunctionSolc(Function):
         # if the loop has a init value /condition or expression
         # There is no way to determine that for(a;;) and for(;a;) are different with old solc
         if 'attributes' in statement:
+            attributes = statement['attributes']
             if 'initializationExpression' in statement:
                 if not statement['initializationExpression']:
                     hasInitExession = False
+            elif 'initializationExpression' in attributes:
+                if not attributes['initializationExpression']:
+                    hasInitExession = False
+
             if 'condition' in statement:
                 if not statement['condition']:
                     hasCondition = False
+            elif 'condition' in attributes:
+                if not attributes['condition']:
+                    hasCondition = False
+
             if 'loopExpression' in statement:
                 if not statement['loopExpression']:
+                    hasLoopExpression = False
+            elif 'loopExpression' in attributes:
+                if not attributes['loopExpression']:
                     hasLoopExpression = False
 
 


### PR DESCRIPTION
This pull request aims to resolve #145 . It adds logic which improves the detection of missing for-loop components via information found in the `attributes` node.

Note: It seems some existing logic might have been trying to access this `attributes` data, but checked one node level higher (the parent of `attributes`, aka the for-loop node itself). Though the logic has been duplicated to maintain existing code, and additionally check `attributes`, in case this was done on purpose for older versions of solidity which may have changed the format.