### PR TITLE
Fix Truffle invocation conflict on Windows

### DIFF
--- a/slither/__main__.py
+++ b/slither/__main__.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import os
+import platform
 import subprocess
 import sys
 import traceback
@@ -76,8 +77,13 @@ def _process(slither, detector_classes, printer_classes):
     return results, analyzed_contracts_count
 
 def process_truffle(dirname, args, detector_classes, printer_classes):
+    # Truffle on windows has naming conflicts where it will invoke truffle.js directly instead
+    # of truffle.cmd (unless in powershell or git bash). The cleanest solution is to explicitly call
+    # truffle.cmd. Reference:
+    # https://truffleframework.com/docs/truffle/reference/configuration#resolving-naming-conflicts-on-windows
     if not args.ignore_truffle_compile:
-        cmd = ['truffle', 'compile']
+        truffle_base_command = "truffle" if platform.system() != 'Windows' else "truffle.cmd"
+        cmd = [truffle_base_command, 'compile']
         if args.truffle_version:
             cmd = ['npx',args.truffle_version,'compile']
         elif os.path.isfile('package.json'):


### PR DESCRIPTION
This pull request aims to resolve #173 . The `truffle compile` command invoked through slither will fail on Windows due to naming conflicts. On Windows, `.JS` is an executable extension by default (see the `PATHEXT` environment variable), which confuses windows into invoking `truffle.js` instead of `truffle.cmd`. 

Truffle's own website suggests a few fixes:
https://truffleframework.com/docs/truffle/reference/configuration#resolving-naming-conflicts-on-windows

The only fix which does not require the user modifying their environment is to explicitly invoke `truffle.cmd`. This seems simplistic and non-problematic, so I have added a switch to `__main__.py` which invokes `truffle.cmd` if on Windows, otherwise simply `truffle` is invoked.

This has fixed truffle invocation on my Windows system.