### PR TITLE
Made inclusion of GENERIC_TAINT sources (msg.*, tx.origin) optional in taint-checking

### DIFF
--- a/slither/analyses/data_dependency/data_dependency.py
+++ b/slither/analyses/data_dependency/data_dependency.py
@@ -63,7 +63,7 @@ GENERIC_TAINT = {SolidityVariableComposed('msg.sender'),
                  SolidityVariableComposed('msg.data'),
                  SolidityVariableComposed('tx.origin')}
 
-def is_tainted(variable, context, only_unprotected=False):
+def is_tainted(variable, context, only_unprotected=False, ignore_generic_taint=False):
     '''
         Args:
         variable
@@ -78,10 +78,11 @@ def is_tainted(variable, context, only_unprotected=False):
         return False
     slither = context.slither
     taints = slither.context[KEY_INPUT]
-    taints |= GENERIC_TAINT
+    if not ignore_generic_taint:
+        taints |= GENERIC_TAINT
     return variable in taints or any(is_dependent(variable, t, context, only_unprotected) for t in taints)
 
-def is_tainted_ssa(variable, context, only_unprotected=False):
+def is_tainted_ssa(variable, context, only_unprotected=False, ignore_generic_taint=False):
     '''
     Args:
         variable
@@ -96,7 +97,8 @@ def is_tainted_ssa(variable, context, only_unprotected=False):
         return False
     slither = context.slither
     taints = slither.context[KEY_INPUT_SSA]
-    taints |= GENERIC_TAINT
+    if not ignore_generic_taint:
+        taints |= GENERIC_TAINT
     return variable in taints or any(is_dependent_ssa(variable, t, context, only_unprotected) for t in taints)
 
 


### PR DESCRIPTION
Made inclusion of `GENERIC_TAINT` sources (`msg.*, tx.origin`) optional in taint-checking by adding `ignore_generic_taint` parameter to `is_tainted()` and `is_tainted_ssa()` functions, with the default value being `FALSE`.

Motivation: There are analyses where one would like to ignore these generic taint sources but only include taint coming from other user-controlled function arguments.

Validation: `tests/controlled_delegatecall.sol` passes with two violations as expected. `scripts/travis_test_data_dependency.sh` passes.

